### PR TITLE
Automatic updater

### DIFF
--- a/update_checker.py
+++ b/update_checker.py
@@ -114,7 +114,7 @@ def check_for_updates() -> None:
             ###
             download_url = data['assets'][0]['browser_download_url'] #Assumes the exe is the first file in Assets
             generate_update_script(download_url)        
-            print("Please wait...")
+            print("Installing update. Please wait...")
             time.sleep(1)
             execute_update_script()
             ###

--- a/update_checker.py
+++ b/update_checker.py
@@ -53,7 +53,7 @@ def download_and_replace(url, filename):
     except Exception as e:
         print(f"Download and replace failed: {{e}}")
 
-download_url = "https://github.com/ElectricityMachine/SCR-SGPlus/releases/download/v0.5.0/sgplus-0.5.0.exe"
+download_url = "{url}"
 download_and_replace(download_url, "sgplus.exe") #Assumes sgplus.exe is the exact file name to be replaced, new version will be downloaded as sgplus.exe regardless but the old version will not be replaced if named something else.
 
 print("Opening new version. Enjoy!\\n\\n\\n")

--- a/update_checker.py
+++ b/update_checker.py
@@ -9,7 +9,9 @@ from semver import Version
 
 from constants import VERSION
 
-import os, shutil, atexit, time, subprocess #for auto updater
+import time
+import subprocess
+
 from sys import exit
 
 # https://python-semver.readthedocs.io/en/latest/advanced/deal-with-invalid-versions.html
@@ -106,7 +108,7 @@ def check_for_updates() -> None:
         if our_tag < tag:
             print(f"{colorama.Fore.RED}NOTICE: A new update is available for SG+!")
             print(
-                "It is always recommended to update to the latest version. To do so, go to https://github.com/ElectricityMachine/SCR-SGPlus" 
+                "It is always recommended to update to the latest version. To do so, go to https://github.com/ElectricityMachine/SCR-SGPlus"
             )
             print('and follow the instructions under "Installation"')
             print(colorama.Fore.WHITE)

--- a/update_checker.py
+++ b/update_checker.py
@@ -9,6 +9,9 @@ from semver import Version
 
 from constants import VERSION
 
+import os, shutil, atexit, time, subprocess #for auto updater
+from sys import exit
+
 # https://python-semver.readthedocs.io/en/latest/advanced/deal-with-invalid-versions.html
 BASEVERSION = re.compile(
     r"""[vV]?
@@ -23,7 +26,49 @@ BASEVERSION = re.compile(
     re.VERBOSE,
 )
 
+UPDATE_SCRIPT_NAME = 'auto-updater.py'
 
+def generate_update_script(url):
+    logging.debug("generate_update_script: called")
+    with open(UPDATE_SCRIPT_NAME, 'w') as update_script:
+        update_script.write(f'''
+import os
+import shutil
+import subprocess
+import sys
+import time
+
+from requests import get as requests_get
+
+def download_and_replace(url, filename):
+    time.sleep(2)
+    try:
+        r = requests_get(url=url, stream=True)
+        print("Latest version downloaded. Please wait while the old version is replaced")
+        with open(filename, 'wb') as f:
+            shutil.copyfileobj(r.raw, f)
+        print("Update completed successfully.")
+    except Exception as e:
+        print(f"Download and replace failed: {{e}}")
+
+download_url = "https://github.com/ElectricityMachine/SCR-SGPlus/releases/download/v0.5.0/sgplus-0.5.0.exe"
+download_and_replace(download_url, "sgplus.exe") #Assumes sgplus.exe is the exact file name to be replaced, new version will be downloaded as sgplus.exe regardless but the old version will not be replaced if named something else.
+
+print("Opening new version. Enjoy!\\n\\n\\n")
+subprocess.Popen("sgplus.exe", creationflags = subprocess.CREATE_NEW_PROCESS_GROUP)
+
+os.remove(__file__)
+''')
+
+def execute_update_script():
+    logging.debug("execute_update_script: called")
+    try:
+        subprocess.Popen(["python", UPDATE_SCRIPT_NAME], creationflags = subprocess.CREATE_NEW_PROCESS_GROUP)
+        exit()
+    except Exception as e:
+        logging.error(f"execute_update_script: Execution failed: {e}")
+        print("Failed to execute update script")
+        
 def coerce(version: str) -> Tuple[Version, Optional[str]]:
     """
     Convert an incomplete version string into a semver-compatible Version
@@ -61,10 +106,19 @@ def check_for_updates() -> None:
         if our_tag < tag:
             print(f"{colorama.Fore.RED}NOTICE: A new update is available for SG+!")
             print(
-                "It is always recommended to update to the latest version. To do so, go to https://github.com/ElectricityMachine/SCR-SGPlus"
+                "It is always recommended to update to the latest version. To do so, go to https://github.com/ElectricityMachine/SCR-SGPlus" 
             )
             print('and follow the instructions under "Installation"')
             print(colorama.Fore.WHITE)
+
+            ###
+            download_url = data['assets'][0]['browser_download_url'] #Assumes the exe is the first file in Assets
+            generate_update_script(download_url)        
+            print("Please wait...")
+            time.sleep(1)
+            execute_update_script()
+            ###
+            
         else:
             logging.info("No new updates found.")
     except requests_exceptions.RequestException as e:

--- a/update_checker.py
+++ b/update_checker.py
@@ -115,7 +115,7 @@ def check_for_updates() -> None:
 
             ###
             download_url = data['assets'][0]['browser_download_url'] #Assumes the exe is the first file in Assets
-            generate_update_script(download_url)        
+            generate_update_script(URL)
             print("Installing update. Please wait...")
             time.sleep(1)
             execute_update_script()

--- a/update_checker.py
+++ b/update_checker.py
@@ -115,7 +115,7 @@ def check_for_updates() -> None:
 
             ###
             download_url = data['assets'][0]['browser_download_url'] #Assumes the exe is the first file in Assets
-            generate_update_script(URL)
+            generate_update_script(download_url)
             print("Installing update. Please wait...")
             time.sleep(1)
             execute_update_script()


### PR DESCRIPTION
Works by creating a new Python script which downloads the latest release and replaces the user's old version.

The idea of creating a new script is to get around the permission errors caused when trying to do the download_and_replace function inside the original program, as it would be attempting to overwrite itself while open. Creating a new script circumvents this. The new script deletes itself after running.

Limitation: only replaces the old version if it is named exactly 'sgplus.exe'. (The new version will still be installed if the old version is called something else)

Not included: Option to enable/disable in the config. Auto update feature makes printed installation instructions redundant but they are not removed.